### PR TITLE
custom arguments into canvas

### DIFF
--- a/examples/customCanvasWithParameters.js
+++ b/examples/customCanvasWithParameters.js
@@ -1,0 +1,47 @@
+import editly from "editly"
+import { loadImage } from "canvas"
+
+async function myFunc({ canvas }) {
+    async function onRender(progress, canvasArgs, offsetTime) {
+      const context = canvas.getContext('2d');    
+      await loadImage(canvasArgs.url).then((image) => {
+        context.drawImage( image, 0, 0, image.width, image.height, pos.x, pos.y, newSizes.width, newSizes.height)
+      })
+    }
+
+    function onClose() {
+      // Cleanup if you initialized anything
+    }
+
+    return { onRender, onClose };
+  }
+
+editly({
+  // fast: true,
+  // outPath: './customCanvas.mp4',
+  outPath: './build/test.mp4',
+  width: 1280,
+  height: 720,
+  clips: [
+    { duration: 5,
+      layers: [
+        { type: 'canvas',
+          func: myFunc , 
+          //Any parameters to fill into canvas
+          canvasArgs : {
+          url : '../assets/image.jpg'
+          }
+        }
+      ] },
+    { duration: 5,
+      layers: [
+        { type: 'canvas',
+          func: myFunc , 
+          //Any parameters to fill into canvas
+          canvasArgs : {
+          url : '../assets/image2.jpg'
+          }
+        }
+      ] },
+  ],
+}).catch(console.error);

--- a/sources/fabric.js
+++ b/sources/fabric.js
@@ -96,9 +96,9 @@ export async function createCustomCanvasFrameSource({ width, height, params }) {
 
   const { onClose, onRender } = await params.func(({ width, height, canvas }));
 
-  async function readNextFrame(progress) {
+  async function readNextFrame(progress, canvas, offsetTime, canvasArgs, duration) {
     context.clearRect(0, 0, canvas.width, canvas.height);
-    await onRender(progress);
+    await onRender(progress, canvasArgs, offsetTime, duration);
     // require('fs').writeFileSync(`${new Date().getTime()}.png`, canvas.toBuffer('image/png'));
     // I don't know any way to draw a node-canvas as a layer on a fabric.js canvas, other than converting to rgba first:
     return canvasToRgba(context);

--- a/sources/frameSource.js
+++ b/sources/frameSource.js
@@ -72,10 +72,12 @@ export async function createFrameSource({ clip, clipIndex, width, height, channe
       const offsetProgress = offsetTime / layer.layerDuration;
       // console.log({ offsetProgress });
       const shouldDrawLayer = offsetProgress >= 0 && offsetProgress <= 1;
-
+      
+      //Canvas arguments
+      const canvasArgs = layer.canvasArgs
       if (shouldDrawLayer) {
         if (logTimes) console.time('frameSource.readNextFrame');
-        const rgba = await frameSource.readNextFrame(offsetProgress, canvas, offsetTime);
+        const rgba = await frameSource.readNextFrame(offsetProgress, canvas, offsetTime, canvasArgs, layer.layerDuration);
         if (logTimes) console.timeEnd('frameSource.readNextFrame');
 
         // Frame sources can either render to the provided canvas and return nothing


### PR DESCRIPTION
use canvasArgs json object to fill any parameters into a canvas. Could be used to create custom canvas (for example with image treatment, share path of the image)